### PR TITLE
✨ feat : 상담 확정 일/시간대 및 상태 변경 기능 구현

### DIFF
--- a/src/main/java/org/likelion/_thon/silver_navi/domain/consult/entity/Consult.java
+++ b/src/main/java/org/likelion/_thon/silver_navi/domain/consult/entity/Consult.java
@@ -6,6 +6,7 @@ import org.likelion._thon.silver_navi.domain.consult.entity.enums.ConsultStatus;
 import org.likelion._thon.silver_navi.domain.consult.entity.enums.ConsultTime;
 import org.likelion._thon.silver_navi.domain.consult.entity.enums.ConsultType;
 import org.likelion._thon.silver_navi.domain.consult.web.dto.ConsultApplyReq;
+import org.likelion._thon.silver_navi.domain.consult.web.dto.ConsultConfirmReq;
 import org.likelion._thon.silver_navi.domain.nursingfacility.entity.NursingFacility;
 import org.likelion._thon.silver_navi.domain.user.entity.User;
 import org.likelion._thon.silver_navi.domain.user.entity.enums.RelationRole;
@@ -53,6 +54,13 @@ public class Consult extends BaseEntity {
     @Column(nullable = false)
     private String content;
 
+    @Column(name = "confirmed_date", nullable = true)
+    private LocalDate confirmedDate;        // 상담 확정일
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "confirmed_time", nullable = true)
+    private ConsultTime confirmedTime;      // 상담 확정 시간
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
@@ -74,5 +82,17 @@ public class Consult extends BaseEntity {
                 .user(user)
                 .facility(facility)
                 .build();
+    }
+
+    public void updateConfirmation(ConsultConfirmReq req) {
+        if (req.getConfirmedDate() != null) {
+            this.confirmedDate = req.getConfirmedDate();
+        }
+        if (req.getConfirmedTime() != null) {
+            this.confirmedTime = req.getConfirmedTime();
+        }
+        if (req.getConsultStatus() != null) {
+            this.consultStatus = req.getConsultStatus();
+        }
     }
 }

--- a/src/main/java/org/likelion/_thon/silver_navi/domain/consult/entity/GeneralConsult.java
+++ b/src/main/java/org/likelion/_thon/silver_navi/domain/consult/entity/GeneralConsult.java
@@ -3,11 +3,15 @@ package org.likelion._thon.silver_navi.domain.consult.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.likelion._thon.silver_navi.domain.consult.entity.enums.ConsultStatus;
+import org.likelion._thon.silver_navi.domain.consult.entity.enums.ConsultTime;
 import org.likelion._thon.silver_navi.domain.consult.entity.enums.InquiryType;
+import org.likelion._thon.silver_navi.domain.consult.web.dto.ConsultConfirmReq;
 import org.likelion._thon.silver_navi.domain.consult.web.dto.GeneralApplyReq;
 import org.likelion._thon.silver_navi.domain.nursingfacility.entity.NursingFacility;
 import org.likelion._thon.silver_navi.domain.user.entity.User;
 import org.likelion._thon.silver_navi.global.entity.BaseEntity;
+
+import java.time.LocalDate;
 
 @Entity
 @Getter
@@ -41,6 +45,13 @@ public class GeneralConsult extends BaseEntity {
     @Column(nullable = false, name = "consult_status")
     private ConsultStatus consultStatus;
 
+    @Column(name = "confirmed_date", nullable = true)
+    private LocalDate confirmedDate;        // 상담 확정일
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "confirmed_time", nullable = true)
+    private ConsultTime confirmedTime;      // 상담 확정 시간
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
@@ -60,5 +71,17 @@ public class GeneralConsult extends BaseEntity {
                 .user(user)
                 .facility(facility)
                 .build();
+    }
+
+    public void updateConfirmation(ConsultConfirmReq req) {
+        if (req.getConfirmedDate() != null) {
+            this.confirmedDate = req.getConfirmedDate();
+        }
+        if (req.getConfirmedTime() != null) {
+            this.confirmedTime = req.getConfirmedTime();
+        }
+        if (req.getConsultStatus() != null) {
+            this.consultStatus = req.getConsultStatus();
+        }
     }
 }

--- a/src/main/java/org/likelion/_thon/silver_navi/domain/consult/service/ConsultService.java
+++ b/src/main/java/org/likelion/_thon/silver_navi/domain/consult/service/ConsultService.java
@@ -21,4 +21,9 @@ public interface ConsultService {
 
     // 상담 정보 상세 보기
     ConsultDetailInfoRes getConsult(ManagerPrincipal managerPrincipal, Long consultId, ConsultCategory consultCategory);
+
+    // 상담 확정일 또는 상태 변경
+    void updateConsult(
+            ManagerPrincipal managerPrincipal, Long consultId, ConsultCategory consultCategory, ConsultConfirmReq consultConfirmReq
+    );
 }

--- a/src/main/java/org/likelion/_thon/silver_navi/domain/consult/service/ConsultServiceImpl.java
+++ b/src/main/java/org/likelion/_thon/silver_navi/domain/consult/service/ConsultServiceImpl.java
@@ -135,4 +135,33 @@ public class ConsultServiceImpl implements ConsultService {
 
         return consultDetailInfoRes;
     }
+
+    @Override
+    @Transactional
+    public void updateConsult(
+            ManagerPrincipal managerPrincipal, Long consultId, ConsultCategory consultCategory, ConsultConfirmReq consultConfirmReq
+    ) {
+        NursingFacility nursingFacility = nursingFacilityRepository.findById(managerPrincipal.getFacilityId())
+                .orElseThrow(FacilityNotFoundException::new);
+
+        if (consultCategory.equals(ConsultCategory.GRADE)) { // 상담
+            Consult consult = consultRepository.findById(consultId)
+                    .orElseThrow(ConsultNotFoundException::new);
+
+            if (!consult.getFacility().getId().equals(nursingFacility.getId())) {
+                throw new ConsultAccessDeniedException();
+            }
+
+            consult.updateConfirmation(consultConfirmReq);
+        } else { // 일반 상담
+            GeneralConsult consult = generalConsultRepository.findById(consultId)
+                    .orElseThrow(ConsultNotFoundException::new);
+
+            if (!consult.getFacility().getId().equals(nursingFacility.getId())) {
+                throw new ConsultAccessDeniedException();
+            }
+
+            consult.updateConfirmation(consultConfirmReq);
+        }
+    }
 }

--- a/src/main/java/org/likelion/_thon/silver_navi/domain/consult/web/controller/ConsultApi.java
+++ b/src/main/java/org/likelion/_thon/silver_navi/domain/consult/web/controller/ConsultApi.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.likelion._thon.silver_navi.domain.consult.web.dto.ConsultConfirmReq;
 import org.likelion._thon.silver_navi.domain.consult.web.dto.ConsultDetailInfoRes;
 import org.likelion._thon.silver_navi.domain.consult.web.dto.ConsultManagementRes;
 import org.likelion._thon.silver_navi.global.auth.jwt.ManagerPrincipal;
@@ -208,5 +209,52 @@ public interface ConsultApi {
     })
     public ResponseEntity<SuccessResponse<ConsultDetailInfoRes>> getConsult(
             ManagerPrincipal managerPrincipal, Long consultId, String category
+    );
+
+
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "상담 확정 일/시간대 또는 상태 변경 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = SuccessResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                                "isSuccess": true,
+                                                "timestamp": "2025-11-09 03:27:07",
+                                                "code": "GLOBAL_200",
+                                                "httpStatus": 200,
+                                                "message": "변경이 성공적으로 되었습니다.",
+                                                "data": null
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "유효하지 않은 값",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = SuccessResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                                "isSuccess": false,
+                                                "timestamp": "2025-11-09 03:31:55",
+                                                "code": "GLOBAL_400_2",
+                                                "httpStatus": 400,
+                                                "message": "입력된 값이 유효하지 않습니다. Enum 타입의 철자나 대소문자를 다시 확인해주세요.",
+                                                "data": null
+                                            }
+                                            """
+                            )
+                    )
+            ),
+    })
+    public ResponseEntity<SuccessResponse<?>> updateConsult(
+            ManagerPrincipal managerPrincipal, Long consultId, String category, ConsultConfirmReq consultConfirmReq
     );
 }

--- a/src/main/java/org/likelion/_thon/silver_navi/domain/consult/web/controller/ConsultController.java
+++ b/src/main/java/org/likelion/_thon/silver_navi/domain/consult/web/controller/ConsultController.java
@@ -88,4 +88,22 @@ public class ConsultController implements ConsultApi {
                 .status(HttpStatus.OK)
                 .body(SuccessResponse.from(consultDetailInfoRes));
     }
+
+    @PatchMapping("/{consultId}/{category}")
+    public ResponseEntity<SuccessResponse<?>> updateConsult(
+            @AuthenticationPrincipal ManagerPrincipal managerPrincipal,
+            @PathVariable Long consultId,
+            @PathVariable String category,
+            @RequestBody @Valid ConsultConfirmReq consultConfirmReq
+    ) {
+        ConsultCategory consultCategory = ConsultCategory.fromValue(category);
+
+        consultService.updateConsult(
+                managerPrincipal, consultId, consultCategory, consultConfirmReq
+        );
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(SuccessResponse.emptyCustom("변경이 성공적으로 되었습니다."));
+    }
 }

--- a/src/main/java/org/likelion/_thon/silver_navi/domain/consult/web/dto/ConsultConfirmReq.java
+++ b/src/main/java/org/likelion/_thon/silver_navi/domain/consult/web/dto/ConsultConfirmReq.java
@@ -1,0 +1,15 @@
+package org.likelion._thon.silver_navi.domain.consult.web.dto;
+
+import lombok.Getter;
+import org.likelion._thon.silver_navi.domain.consult.entity.enums.ConsultStatus;
+import org.likelion._thon.silver_navi.domain.consult.entity.enums.ConsultTime;
+
+import java.time.LocalDate;
+
+@Getter
+public class ConsultConfirmReq {
+
+    private LocalDate confirmedDate;        // 상담 확정 날짜
+    private ConsultTime confirmedTime;      // 상담 확정 시간대, enum: MORNING / AFTERNOON / EVENING
+    private ConsultStatus consultStatus;    // 상담 상태
+}


### PR DESCRIPTION
## 🔍 관련 이슈
<!--
- close #123
-->
- close #77 

<br>

## ✅ 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경
- [ ] 코드 리팩토링
- [ ] 기능 수정

<br>

## ✨ 작업 내용
<!--
  ex) 
  1. 네 발 짐승 클래스에 `크앙` 함수 추가
  2. 고양이 클래스에서 `크앙` 함수에 `미야아옹.wav` 재생시킴
-->
1. 상담 확정 일/시간대 변경 기능 구현
2. 상담 상태 변경 기능 구현

<br>

## 👥 전달사항
<!--
1. User 도메인 구조를 변경하였습니다.
2. User 도메인 사용자 닉네임 필드를 username -> nickname으로 변경하였습니다.
-->
1. `Consult`, `GeneralConsult` 테이블에 `confirmedDate(상담 확정일), confirmedTime(상담 확정시간대)` 필드 추가했습니다.

<br>

## ✅ 체크리스트
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨
- [x] 커밋 메시지를 확인함

<br>

## 📸 스크린샷
<!--포스트맨 테스트 스크린 샷을 업로드해주세요.-->
<img width="338" height="150" alt="image" src="https://github.com/user-attachments/assets/65046e5b-6e97-484c-a57c-dc2f0665ada7" />
<img width="1051" height="78" alt="image" src="https://github.com/user-attachments/assets/6ab1f093-27bf-4ed7-8eeb-0b7a17dbaced" />
