### PR TITLE
🐛 fix: 상담 답변 로직 수정 및 DB 저장 버그 수정

### DIFF
--- a/src/main/java/org/likelion/_thon/silver_navi/domain/consult/entity/Consult.java
+++ b/src/main/java/org/likelion/_thon/silver_navi/domain/consult/entity/Consult.java
@@ -93,16 +93,20 @@ public class Consult extends BaseEntity {
             throw new ConsultModifyNotAllowedException();
         }
 
-        if (req.getConfirmedDate() != null) {
-            this.confirmedDate = req.getConfirmedDate();
-        }
-        if (req.getConfirmedTime() != null) {
-            this.confirmedTime = req.getConfirmedTime();
-        }
-        if (req.getConsultStatus() != null) {
-            if (req.getConsultStatus().equals(ConsultStatus.REJECTED)) {
-                this.consultStatus = ConsultStatus.COMPLETED;
-            } else this.consultStatus = req.getConsultStatus();
+        if (req.getConsultStatus().equals(ConsultStatus.REJECTED)) {
+            this.confirmedDate = null;
+            this.confirmedTime = null;
+            this.consultStatus = ConsultStatus.COMPLETED;
+        } else {
+            if (req.getConfirmedDate() != null) {
+                this.confirmedDate = req.getConfirmedDate();
+            }
+            if (req.getConfirmedTime() != null) {
+                this.confirmedTime = req.getConfirmedTime();
+            }
+            if (req.getConsultStatus() != null) {
+                this.consultStatus = req.getConsultStatus();
+            }
         }
     }
 

--- a/src/main/java/org/likelion/_thon/silver_navi/domain/consult/entity/GeneralConsult.java
+++ b/src/main/java/org/likelion/_thon/silver_navi/domain/consult/entity/GeneralConsult.java
@@ -78,16 +78,20 @@ public class GeneralConsult extends BaseEntity {
             throw new ConsultModifyNotAllowedException();
         }
 
-        if (req.getConfirmedDate() != null) {
-            this.confirmedDate = req.getConfirmedDate();
-        }
-        if (req.getConfirmedTime() != null) {
-            this.confirmedTime = req.getConfirmedTime();
-        }
-        if (req.getConsultStatus() != null) {
-            if (req.getConsultStatus().equals(ConsultStatus.REJECTED)) {
-                this.consultStatus = ConsultStatus.COMPLETED;
-            } else this.consultStatus = req.getConsultStatus();
+        if (req.getConsultStatus().equals(ConsultStatus.REJECTED)) {
+            this.confirmedDate = null;
+            this.confirmedTime = null;
+            this.consultStatus = ConsultStatus.COMPLETED;
+        } else {
+            if (req.getConfirmedDate() != null) {
+                this.confirmedDate = req.getConfirmedDate();
+            }
+            if (req.getConfirmedTime() != null) {
+                this.confirmedTime = req.getConfirmedTime();
+            }
+            if (req.getConsultStatus() != null) {
+                this.consultStatus = req.getConsultStatus();
+            }
         }
     }
 

--- a/src/main/java/org/likelion/_thon/silver_navi/domain/consult/service/ConsultServiceImpl.java
+++ b/src/main/java/org/likelion/_thon/silver_navi/domain/consult/service/ConsultServiceImpl.java
@@ -208,9 +208,6 @@ public class ConsultServiceImpl implements ConsultService {
             if (consultReplyRepository.existsByConsult_Id(req.getConsultId())) {
                 throw new ConsultReplyAlreadyExistsException();
             }
-            user = consult.getUser();
-            consultId = consult.getId();
-            consultCategory = ConsultCategory.GRADE;
 
             ConsultReply reply = ConsultReply.toEntity(req.getContent(), consult, null);
 
@@ -220,6 +217,12 @@ public class ConsultServiceImpl implements ConsultService {
                     .consultStatus(req.getConsultStatus())
                     .build();
             consult.updateConfirmation(confirmReq);
+
+            consult.consultReply(reply);
+
+            user = consult.getUser();
+            consultId = consult.getId();
+            consultCategory = ConsultCategory.GRADE;
         } else {
             GeneralConsult consult = generalConsultRepository.findById(req.getConsultId())
                     .orElseThrow(ConsultNotFoundException::new);


### PR DESCRIPTION
## 🔍 관련 이슈
<!--
- close #123
-->
- close #112 

<br>

## ✅ 작업 분류
- [x] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경
- [ ] 코드 리팩토링
- [ ] 기능 수정

<br>

## ✨ 작업 내용
<!--
  ex) 
  1. 네 발 짐승 클래스에 `크앙` 함수 추가
  2. 고양이 클래스에서 `크앙` 함수에 `미야아옹.wav` 재생시킴
-->
1. `/api/consults/reply` 비즈니스 로직 수정
   - 기존에는 '답변(승인)'만 처리했으나, '거절' 시에도 해당 API를 사용하도록 로직 통합
   - 거절 사유 저장: 거절 시 `content` 컬럼에 거절 사유가 저장되도록 변경
2. 시설 상담에 대한 답변 or 거부할 때, consultReply 테이블에 저장되지 않던 버그 수정

<br>

## 👥 전달사항
<!--
1. User 도메인 구조를 변경하였습니다.
4. User 도메인 사용자 닉네임 필드를 username -> nickname으로 변경하였습니다.
-->
1. 현재 상담 승인/거부할 때 상태가 전부 `COMPLETED`로 저장되기 때문에, 거부할 때는 상담 확정 날짜, 시간을 `null`로 처리하여 구분


<br>

## ✅ 체크리스트
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨
- [x] 커밋 메시지를 확인함

<br>

## 📸 스크린샷
<!--포스트맨 테스트 스크린 샷을 업로드해주세요.-->
- 로직 수정
<img width="705" height="67" alt="image" src="https://github.com/user-attachments/assets/af4d8de9-43bc-41b5-9c49-1d50073f4eb5" />

- 승인
<img width="1160" height="52" alt="image" src="https://github.com/user-attachments/assets/65f7e67f-b1ba-4870-a209-b2f593ca5e15" />

- 거부
<img width="1408" height="48" alt="image" src="https://github.com/user-attachments/assets/b28cad2c-41ff-4c3d-8656-b509782c65f7" />

- 사용자 알림 리스트
<img width="416" height="571" alt="image" src="https://github.com/user-attachments/assets/829f9ca3-275f-4c17-85c2-60121c2558fa" />
